### PR TITLE
Add researcher types

### DIFF
--- a/server/models/researcher.model.js
+++ b/server/models/researcher.model.js
@@ -3,6 +3,11 @@ const mongoose = require('../common/services/mongoose.service').mongoose;
 const Schema = mongoose.Schema;
 
 const researcherSchema = Schema({
+   type: {
+      type: String,
+      enum: ['Researcher', 'Coordinator', 'Partner'],
+      default: 'Researcher'
+   },
    name: String,
    abbreviation: String,
    headline: String,

--- a/src/app/admin-view/admin-forms/researcher-form/researcher-form.component.html
+++ b/src/app/admin-view/admin-forms/researcher-form/researcher-form.component.html
@@ -3,6 +3,16 @@
 <h4>Researcher {{title}}</h4>
 
   <form [formGroup]="researcherForm" (ngSubmit)="onSubmit()"  class="gridTable row-1 forms">
+    <!-- type (select One) -->
+    <mat-form-field>
+      <mat-label>Type</mat-label>
+      <mat-select formControlName="type">
+        <mat-option *ngFor="let type of types" [value]="type">
+          {{type}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <br/>
     <!-- name -->
     <mat-form-field>
       <input matInput formControlName="name" maxlength="50" placeholder="Researcher name">

--- a/src/app/admin-view/admin-forms/researcher-form/researcher-form.component.ts
+++ b/src/app/admin-view/admin-forms/researcher-form/researcher-form.component.ts
@@ -4,7 +4,7 @@ import { MyErrorStateMatcher } from '../MyErrorStateMatcher';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Researcher } from '../../../shared/models/researcher';
+import { Researcher, ResearcherTypes } from '../../../shared/models/researcher';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
@@ -21,6 +21,7 @@ export class ResearcherFormComponent implements OnInit, OnDestroy {
 
   matcher = new MyErrorStateMatcher();
   subs: Subscription[] = [];
+  types: ResearcherTypes[];
   researcher: Researcher;
 
   constructor(
@@ -30,8 +31,10 @@ export class ResearcherFormComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar) { }
 
   ngOnInit() {
+    this.types = Object.values(ResearcherTypes);
     this.researcher = this.activatedRoute.snapshot.data.researcher;
     this.researcherForm = this.formBuilder.group({
+      type: ['', Validators.required],
       email: ['', [Validators.email, Validators.required]],
       name: ['', Validators.required],
       abbreviation: ['', Validators.required],
@@ -45,10 +48,13 @@ export class ResearcherFormComponent implements OnInit, OnDestroy {
     if (this.researcher != null ) {
       this.title = 'Edition';
       this.fillForm();
+    } else {      
+      this.researcherForm.get('type').setValue(ResearcherTypes.Researcher);
     }
   }
 
   fillForm() {
+    this.researcherForm.get('type').setValue(this.researcher.type);
     this.researcherForm.get('email').setValue(this.researcher.email);
     this.researcherForm.get('name').setValue(this.researcher.name);
     this.researcherForm.get('abbreviation').setValue(this.researcher.abbreviation);

--- a/src/app/shared/models/researcher.ts
+++ b/src/app/shared/models/researcher.ts
@@ -1,5 +1,12 @@
+export enum ResearcherTypes {
+  Researcher = 'Researcher',
+  Coordinator = 'Coordinator',
+  Partner = 'Partner'
+}
+
 export interface Researcher {
   _id: string;
+  type: ResearcherTypes;
   name: string;
   abbreviation: string;
   headline: string;


### PR DESCRIPTION
* No caso do BD, outra forma de implementar que reduziria o espaço utilizado seria criar uma tabela só para os tipos e utilizar os inteiros referentes às IDs ao invés de strings. Mas por outro lado, as strings são mais legíveis. O que acha?
* No caso do código, acho que seria melhor ter um enum global para manter os tipos em um único lugar. Talvez em um arquivo `globals.d.ts` na pasta principal?